### PR TITLE
V051

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## 0.5.1
+  * make sha256 the default again as it turns out sha3_256 isn't widely supported enough yet.
+
 ## 0.5.0
   * Fixed an issue calculating the scale factor used in many of the functions. Now, correctly, uses the units_per_em instead of ascent-descent for the baseline.
   * Removed the serialization APIs. Scenic no longer needs them and how you serialize the data in not an opinion the package should have. Use MsgPack. Use :erlang.term_to_binary. Use Jason. This package shouldn't care.

--- a/lib/font_metrics.ex
+++ b/lib/font_metrics.ex
@@ -81,7 +81,7 @@ defmodule FontMetrics do
   # high-level functions
 
   def version(), do: @version
-  def expected_hash(), do: :sha3_256
+  def expected_hash(), do: :sha256
 
   # ============================================================================
   # validity checks

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule FontMetrics.MixProject do
 
   @app_name :font_metrics
 
-  @version "0.5.0"
+  @version "0.5.1"
 
   @elixir_version "~> 1.7"
   @github "https://github.com/boydm/font_metrics"

--- a/test/font_metrics_test.exs
+++ b/test/font_metrics_test.exs
@@ -18,7 +18,7 @@ defmodule FontMetricsTest do
                   |> :erlang.binary_to_term()
 
   @version "0.1.1"
-  @hash_type :sha3_256
+  @hash_type :sha256
 
   # ============================================================================
 


### PR DESCRIPTION
Go back to sha256 as sha3_256 isn't widely supported enough yet. You'd think it would be but it isn't.