### PR TITLE
Use position zero for start of string in position at

### DIFF
--- a/lib/font_metrics.ex
+++ b/lib/font_metrics.ex
@@ -177,31 +177,6 @@ defmodule FontMetrics do
 
   # --------------------------------------------------------
   @doc """
-  Return the height of a line of text. The response is scaled to the pixel size.
-  Adapted from this code: https://github.com/ScenicFramework/scenic_driver_local/blob/main/c_src/nanovg/fontstash.h#L964
-  """
-  @spec line_height(pixels :: number, metrics :: FontMetrics.t()) :: line_height :: number
-  def line_height(pixels, fm = %FontMetrics{ascent: ascent, descent: descent, max_box: {x_min, y_min, x_max, y_max}, line_gap: line_gap, units_per_em: u_p_m}) do
-    # test_line_gap = pixels - (ascender-descender)
-    # full_ascent = ascent + test_line_gap
-    # font_height = full_ascent - descent
-    # ascender = full_ascent / font_height
-    # descender = descent / font_height
-
-    # require IEx; IEx.pry()
-
-    # IO.inspect fm
-
-    # line_height = ascender - descender
-    # scale = pixels / u_p_m
-    # line_height * pixels
-    # (y_max - y_min) * (pixels / u_p_m)
-
-    (ascent + line_gap - descent) * (pixels / u_p_m)
-  end
-
-  # --------------------------------------------------------
-  @doc """
   Measure the width of a string, scaled to a pixel size
 
   ## Options
@@ -628,7 +603,7 @@ defmodule FontMetrics do
   defp do_position_at(line, n, cp_metrics, kerning, kern, k_next \\ 0, line_no \\ 0, width \\ 0)
 
   defp do_position_at('', _, _, _, _, _, line_no, width), do: {width, line_no}
-  defp do_position_at(_, -1, _, _, _, _, line_no, width), do: {width, line_no}
+  defp do_position_at(_, p, _, _, _, _, line_no, width) when p <= 0, do: {width, line_no}
 
   # handle newlines
   defp do_position_at([10 | cps], n, cp_metrics, kerning, kern, _, line_no, _) do

--- a/lib/font_metrics.ex
+++ b/lib/font_metrics.ex
@@ -177,6 +177,31 @@ defmodule FontMetrics do
 
   # --------------------------------------------------------
   @doc """
+  Return the height of a line of text. The response is scaled to the pixel size.
+  Adapted from this code: https://github.com/ScenicFramework/scenic_driver_local/blob/main/c_src/nanovg/fontstash.h#L964
+  """
+  @spec line_height(pixels :: number, metrics :: FontMetrics.t()) :: line_height :: number
+  def line_height(pixels, fm = %FontMetrics{ascent: ascent, descent: descent, max_box: {x_min, y_min, x_max, y_max}, line_gap: line_gap, units_per_em: u_p_m}) do
+    # test_line_gap = pixels - (ascender-descender)
+    # full_ascent = ascent + test_line_gap
+    # font_height = full_ascent - descent
+    # ascender = full_ascent / font_height
+    # descender = descent / font_height
+
+    # require IEx; IEx.pry()
+
+    # IO.inspect fm
+
+    # line_height = ascender - descender
+    # scale = pixels / u_p_m
+    # line_height * pixels
+    # (y_max - y_min) * (pixels / u_p_m)
+
+    (ascent + line_gap - descent) * (pixels / u_p_m)
+  end
+
+  # --------------------------------------------------------
+  @doc """
   Measure the width of a string, scaled to a pixel size
 
   ## Options

--- a/test/font_metrics_test.exs
+++ b/test/font_metrics_test.exs
@@ -185,6 +185,19 @@ defmodule FontMetricsTest do
     assert 2*five_w == ten_w
   end
 
+  test "the length of an empty string is zero" do
+    {w1, 0} = FontMetrics.position_at("", 0, 22, @roboto_metrics)
+    {w2, 0} = FontMetrics.position_at("", 1, 22, @roboto_metrics)
+    assert w1 == 0
+    assert w1 == w2
+  end
+
+  test "position one returns the same length as a one-character long string" do
+    {w1, 0} = FontMetrics.position_at("a", 1, 22, @roboto_metrics)
+    {w2, 0} = FontMetrics.position_at("aaaa", 1, 22, @roboto_metrics)
+    assert w1 == w2
+  end
+
   test "position_at works with a multiline string" do
     string = "PANCAKE breafasts\nPANCAKE are yummy"
     {w, 1} = FontMetrics.position_at(string, 25, 22, @roboto_metrics)

--- a/test/font_metrics_test.exs
+++ b/test/font_metrics_test.exs
@@ -163,21 +163,36 @@ defmodule FontMetricsTest do
   test "position_at works with a simple string" do
     string = "PANCAKE breafasts are yummy"
     {w, 0} = FontMetrics.position_at(string, 8, 22, @roboto_metrics)
-    assert trunc(w) == 116
+    assert trunc(w) == 104
     {w, 0} = FontMetrics.position_at(string, 8, 22, @bitter_metrics)
-    assert trunc(w) == 123
+    assert trunc(w) == 110
     {w, 0} = FontMetrics.position_at(string, 8, 22, @bitter_metrics, kern: true)
-    assert trunc(w) == 121
+    assert trunc(w) == 108
+  end
+
+  test "position_at returns zero length at position 0" do
+    string = "PANCAKE breafasts are yummy"
+    {w, 0} = FontMetrics.position_at(string, 0, 22, @roboto_metrics)
+    assert w == 0
+  end
+
+  test "with just one character, different positions in the string are multiples of the same width" do
+    string = "AAAAAAAAAA" # 10 chars long
+    {w, 0} = FontMetrics.position_at(string, 1, 22, @roboto_metrics)
+    {five_w, 0} = FontMetrics.position_at(string, 5, 22, @roboto_metrics)
+    assert 5*w == five_w
+    {ten_w, 0} = FontMetrics.position_at(string, 10, 22, @roboto_metrics)
+    assert 2*five_w == ten_w
   end
 
   test "position_at works with a multiline string" do
     string = "PANCAKE breafasts\nPANCAKE are yummy"
     {w, 1} = FontMetrics.position_at(string, 25, 22, @roboto_metrics)
-    assert trunc(w) == 104
+    assert trunc(w) == 98
     {w, 1} = FontMetrics.position_at(string, 25, 22, @bitter_metrics)
-    assert trunc(w) == 110
+    assert trunc(w) == 105
     {w, 1} = FontMetrics.position_at(string, 25, 22, @bitter_metrics, kern: true)
-    assert trunc(w) == 108
+    assert trunc(w) == 103
   end
 
   # ============================================================================


### PR DESCRIPTION
I think this is a bug, let me know if it was actually intentional... right now `position_at` counts position zero as being the first character, so getting a string width at position zero returns the width of 1 character. Position 1 will show the width of 2 characters, etc

```
iex(10)> s
"AAA"
iex(5)> FontMetrics.position_at(s, 0, 12, bm)
{8.700000000000001, 0}
iex(6)> FontMetrics.position_at(s, 1, 12, bm)
{17.400000000000002, 0}
iex(7)> FontMetrics.position_at(s, 2, 12, bm)
{26.1, 0}
iex(8)> FontMetrics.position_at(s, 2, 12, bm)
{26.1, 0}
iex(9)> FontMetrics.position_at(s, 3, 12, bm)
{26.1, 0}
iex(11)> FontMetrics.position_at(s, 10, 12, bm)
{26.1, 0}
```

I think position 0 should return a length of zero, to make it more consistent with how String.length/1 works:

```
iex(1)> String.length("")
0
iex(2)> String.length("1")
1
```

The way I discovered this was when working on positioning a cursor, I was using String.length/1 to figure out where to place my cursor - but due to the way position_at currently works (over-estimating the position by one character) moving my cursor back 1 character wasn't achieving the desired effect. With these changes now my cursor works well. Note though that this might end up affecting other people's code, including the existing TextBox component (I haven't checked this I'm just guessing) if they work by depending on the current behaviour