### PR TITLE
fix infinite loop when wrapping very long word

### DIFF
--- a/lib/font_metrics.ex
+++ b/lib/font_metrics.ex
@@ -703,14 +703,21 @@ defmodule FontMetrics do
       |> String.trim()
 
     # test if new_out goes past max_width. If it does, return it there
-    case width(test_line, pixels, fm, kern: opts[:kern]) > max_width do
-      # too long
-      true ->
-        do_wrap_words(words, max_width, pixels, fm, opts, "", [line | lines])
+    test_width = width(test_line, pixels, fm, kern: opts[:kern])
 
-      # keep going
-      false ->
+    cond do
+      test_width <= max_width ->
+        # keep going
         do_wrap_words(tail, max_width, pixels, fm, opts, test_line, lines)
+
+      line == "" ->
+        # single word too long for line
+        # just make this word the whole line and hope for the best
+        do_wrap_words(tail, max_width, pixels, fm, opts, "", [test_line | lines])
+
+      true ->
+        # too long
+        do_wrap_words(words, max_width, pixels, fm, opts, "", [line | lines])
     end
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -21,6 +21,6 @@
   "nimble_options": {:hex, :nimble_options, "0.3.5", "a4f6820cdcb4ee444afd78635f323e58e8a5ddf2fbbe9b9d283a99f972034bae", [:mix], [], "hexpm", "f5507cc90033a8d12769522009c80aa9164af6bab245dbd4ad421d008455f1e1"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/font_metrics_test.exs
+++ b/test/font_metrics_test.exs
@@ -258,6 +258,7 @@ defmodule FontMetricsTest do
 
   @long_str "This is a long string that will be wrapped because it is too wide."
   @long_ret "This is a long string that will be wrapped because it is too wide\nIt also deals with returns in the string"
+  @long_word "This is a long string that will be wrapped with an excessssssssssssssively long word."
 
   test "wrap wraps a string - at word boundaries by default" do
     assert FontMetrics.wrap(@long_str, 110, 22, @roboto_metrics) ==
@@ -287,5 +288,10 @@ defmodule FontMetricsTest do
   test "wrap wraps a string with a return - at character boundaries" do
     assert FontMetrics.wrap(@long_ret, 110, 22, @roboto_metrics, wrap: :char) ==
              "This is a lo\nng string t\nhat will be \nwrapped b\necause it i\ns too wide\nIt also deal\ns with retur\nns in the st\nring"
+  end
+
+  test "wrap wraps a string - at word boundaries - with a very long word" do
+    assert FontMetrics.wrap(@long_word, 110, 22, @roboto_metrics, wrap: :word) ==
+             "This is a\nlong string\nthat will be\nwrapped\nwith an\nexcessssssssssssssively\nlong word."
   end
 end


### PR DESCRIPTION
If a word is longer than the entire line, v0.3.1 will loop forever (or at least until it runs out of memory).  This change causes it to wrap the word as the whole line and move on.

Technically this generates text that wraps longer than the requested maximum width, but it doesn't really have a very good option.  If the user wants to clip the rendered text at the maximum width, they'll need to do that explicitly.